### PR TITLE
(MODULES-8438) Install 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+## Added
+
+- Add support for installing and managing SQL 2019 instances ([MODULES-8438](https://tickets.puppetlabs.com/browse/MODULES-8438))
+
 ## [2.2.0] - 2018-12-3
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ## Overview
 
-The sqlserver module installs and manages Microsoft SQL Server 2012, 2014, 2016 and 2017 on Windows systems.
+The sqlserver module installs and manages Microsoft SQL Server 2012, 2014, 2016, 2017, 2019 on Windows systems.
 
 ## Module Description
 
@@ -1068,7 +1068,7 @@ Terminology differs somewhat between various database systems; please refer to t
 
 ## Limitations
 
-SQL 2017 detection support has been added. This support is limited to functionality already present for other versions. No new SQL 2017 specific functionality has been added in this release.
+SQL 2017, and 2019 detection support has been added. This support is limited to functionality already present for other versions. No new SQL 2017 specific functionality has been added in this release.
 
 This module can manage only a single version of SQL Server on a given host (one and only one of SQL Server 2012, 2014 or 2016). The module is able to manage multiple SQL Server instances of the same version.
 

--- a/lib/puppet_x/sqlserver/features.rb
+++ b/lib/puppet_x/sqlserver/features.rb
@@ -4,8 +4,9 @@ SQL_2012 ||= 'SQL_2012'
 SQL_2014 ||= 'SQL_2014'
 SQL_2016 ||= 'SQL_2016'
 SQL_2017 ||= 'SQL_2017'
+SQL_2019 ||= 'SQL_2019'
 
-ALL_SQL_VERSIONS ||= [SQL_2012, SQL_2014, SQL_2016, SQL_2017]
+ALL_SQL_VERSIONS ||= [SQL_2012, SQL_2014, SQL_2016, SQL_2017, SQL_2019]
 
 module PuppetX
   module Sqlserver
@@ -32,6 +33,10 @@ module PuppetX
         SQL_2017 => {
           :major_version => 14,
           :registry_path => '140',
+        },
+        SQL_2019 => {
+          :major_version => 15,
+          :registry_path => '150',
         }
       }
 

--- a/metadata.json
+++ b/metadata.json
@@ -38,6 +38,7 @@
     "sql2014",
     "sql2016",
     "sql2017",
+    "sql2019",
     "tsql",
     "database"
   ],

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -11,6 +11,7 @@ require 'beaker/testmode_switcher/dsl'
 WIN_ISO_ROOT = "http://int-resources.ops.puppetlabs.net/ISO/Windows/2012"
 WIN_2012R2_ISO = "en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso"
 QA_RESOURCE_ROOT = "http://int-resources.ops.puppetlabs.net/QA_resources/microsoft_sql/iso/"
+SQL_2019_ISO = "en_sql_server_2019_developer_x64_CTP2.iso"
 SQL_2016_ISO = "en_sql_server_2016_enterprise_with_service_pack_1_x64_dvd_9542382.iso"
 SQL_2014_ISO = "SQLServer2014-x64-ENU.iso"
 SQL_2012_ISO = "SQLServer2012SP1-FullSlipstream-ENU-x64.iso"


### PR DESCRIPTION
This change allows the module to install and uninstall SQL 2019
idempotently. No further support is implemented.