### PR TITLE
(MAINT) Fix Jenkins CI Pipelines

### DIFF
--- a/spec/acceptance/z_last_sqlserver_features_spec.rb
+++ b/spec/acceptance/z_last_sqlserver_features_spec.rb
@@ -217,9 +217,10 @@ describe "sqlserver_features", :node => host do
         ensure_sql_features(features)
 
         validate_sql_install(host, {:version => sql_version}) do |r|
-          expect(r.stdout).to match(/Client Tools Connectivity/)
-          expect(r.stdout).to match(/Client Tools Backwards Compatibility/)
-          expect(r.stdout).to match(/Client Tools SDK/)
+          # SQL Server 2016 will not install the client tools features.
+          expect(r.stdout).to match(/Client Tools Connectivity/) unless sql_version.to_i >= 2016
+          expect(r.stdout).to match(/Client Tools Backwards Compatibility/) unless sql_version.to_i >= 2016
+          expect(r.stdout).to match(/Client Tools SDK/) unless sql_version.to_i >= 2016
           expect(r.stdout).to match(/Integration Services/)
           expect(r.stdout).to match(/Master Data Services/)
         end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -8,12 +8,12 @@ require 'beaker/testmode_switcher'
 require 'beaker/testmode_switcher/dsl'
 
 
-WIN_ISO_ROOT = "http://int-resources.ops.puppetlabs.net/ISO/Windows/2012"
+WIN_ISO_ROOT = "https://artifactory.delivery.puppetlabs.net/artifactory/generic__iso/iso/windows"
 WIN_2012R2_ISO = "en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso"
-QA_RESOURCE_ROOT = "http://int-resources.ops.puppetlabs.net/QA_resources/microsoft_sql/iso/"
-SQL_2019_ISO = "en_sql_server_2019_developer_x64_CTP2.iso"
+QA_RESOURCE_ROOT = "https://artifactory.delivery.puppetlabs.net/artifactory/generic__iso/iso/SQLServer"
+SQL_2019_ISO = "SQLServer-2019-CTP2-x64-ENU.iso"
 SQL_2016_ISO = "en_sql_server_2016_enterprise_with_service_pack_1_x64_dvd_9542382.iso"
-SQL_2014_ISO = "SQLServer2014-x64-ENU.iso"
+SQL_2014_ISO = "SQLServer2014SP3-FullSlipstream-x64-ENU.iso"
 SQL_2012_ISO = "SQLServer2012SP1-FullSlipstream-ENU-x64.iso"
 SQL_ADMIN_USER = 'sa'
 SQL_ADMIN_PASS = 'Pupp3t1@'


### PR DESCRIPTION
The int-resources server that was housing ISO files that this module needed
for testing recently died. This change migrates those resources to Artifactory.

Also during testing I noticed that the test for SQL Server features install
was not properly guarded for SQLServer 2016, which in one of the test scenarios
will not install Client Connectivity Tools.

The two commits are in one PR because if they are not both in place the Pipeline
will not go green.